### PR TITLE
Add basic autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if `which libtoolize` ; then
+	libtoolize
+# on, e.g., Darwin
+elif `which glibtoolize` ; then
+	glibtoolize
+else
+	echo "libtoolize not found!"
+	exit 1
+fi
+
+aclocal
+autoconf
+automake --add-missing


### PR DESCRIPTION
Since the buildsystem is now automake based, and a simple autoreconf doesn't work, this adds a basic autogen.sh to automate building the configure script.
