### PR TITLE
Fix Windows crash-on-exit caused by freeing in-use buffers.

### DIFF
--- a/src/sound_win32.c
+++ b/src/sound_win32.c
@@ -143,6 +143,8 @@ static void deinit(void)
 	int i;
 
 	if (hwaveout) {
+		waveOutReset(hwaveout);
+
 		for (i = 0; i < num_buffers; i++) {
 			if (header[i].dwFlags & WHDR_PREPARED)
 				waveOutUnprepareHeader(hwaveout, &header[i],


### PR DESCRIPTION
This fixes a crash caused by freeing buffers that are still in use after failed `waveOutUnprepareHeader` calls. Calling `waveOutReset` first stops playback and releases the buffers, allowing `waveOutUnprepareHeader` to succeed consistently. Fixes #19. 