### PR TITLE
Remove sequence change workaround for old libxmp

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -103,18 +103,10 @@ static void change_sequence(xmp_context handle, struct xmp_module_info *mi, stru
 
 	seq += i;
 
-	/* This should never happen with libxmp 4.0.5 or newer */
-	while (mi->seq_data[seq].duration <= 0)
-		seq += i;
-
 	if (seq >= mi->num_sequences) {
 		seq = 0;
 	} else if (seq < 0) {
 		seq = mi->num_sequences - 1;
-
-		/* This should never happen with libxmp 4.0.5 or newer */
-		while (mi->seq_data[seq].duration <= 0)
-			seq--;
 	}
 
 	if (seq == ctl->sequence) {


### PR DESCRIPTION
A workaround for sequence changes when using libxmp 4.0.4 or older
was causing memory access violations. Since we currently require
libxmp 4.4, we can safely drop this workaround.

Fixes #21

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>