### PR TITLE
add --with-libxmp-lite to build against libxmp-lite instead of libxmp.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,10 +29,18 @@ esac
 AC_PROG_INSTALL
 AM_INIT_AUTOMAKE([foreign subdir-objects tar-pax])
 
+AC_ARG_WITH([libxmp-lite],
+  AC_HELP_STRING([--with-libxmp-lite],[build against libxmp-lite instead of libxmp]),
+  [xmplib="$withval"],[xmplib=xmp])
+case "$xmplib" in
+  no|xmp) xmplib=xmp ;;
+  *) xmplib=xmp-lite ;;
+esac
+
 old_LDFLAGS="${LDFLAGS}"
-PKG_CHECK_MODULES([libxmp], [libxmp >= 4.4],
-  LDFLAGS="${LDFLAGS} ${libxmp_LIBS}"
-  AC_CHECK_LIB(xmp, xmp_set_player, [LDFLAGS="${old_LDFLAGS}"], [exit 1]),
+PKG_CHECK_MODULES([LIBXMP], [lib$xmplib >= 4.4],
+  LDFLAGS="${LDFLAGS} ${LIBXMP_LIBS}"
+  AC_CHECK_LIB($xmplib, xmp_set_player, [LDFLAGS="${old_LDFLAGS}"], [exit 1]),
   [echo "You need libxmp version 4.4 or later to build this package"; exit 1]
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 # -*- Makefile -*-
 
-AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" ${libxmp_CFLAGS} \
+AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" ${LIBXMP_CFLAGS} \
               ${alsa_CFLAGS} ${pulseaudio_CFLAGS}
 AM_CFLAGS   = -Wall
 
@@ -10,7 +10,7 @@ xmp_SOURCES = \
 	commands.c common.h getopt.h list.h getopt.c getopt1.c info.c main.c \
 	options.c read_config.c sound.c sound.h sound_file.c sound_null.c \
 	sound_wav.c sound_aiff.c terminal.c
-xmp_LDADD   = ${libxmp_LIBS}
+xmp_LDADD   = ${LIBXMP_LIBS}
 xmp_LDFLAGS = ${XMP_DARWIN_LDFLAGS}
 
 if SOUND_OSS


### PR DESCRIPTION
Otherwise, if only libxmp-lite is installed, xmp-cli configury fails.