### PR TITLE
SYSCONFDIR fixes for #27

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 # -*- Makefile -*-
 
-AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}\" ${LIBXMP_CFLAGS} \
+AM_CPPFLAGS = -DSYSCONFDIR=\"${sysconfdir}/${PACKAGE_NAME}\" ${LIBXMP_CFLAGS} \
               ${alsa_CFLAGS} ${pulseaudio_CFLAGS}
 AM_CFLAGS   = -Wall
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -17,6 +17,10 @@
 #include <sys/unistd.h>
 #endif
 
+#if !defined(SYSCONFDIR)
+#define SYSCONFDIR "."
+#endif
+
 static char driver[32];
 static char instrument_path[256];
 


### PR DESCRIPTION
1. fix xmp-cli not respecting system xmp.conf.
   
   src/Makefile.am defined SYSCONFDIR as ${sysconfdir}, but installed
   xmp.conf under ${sysconfdir}//${PACKAGE_NAME}. therefore, changing
   the SYSCONFDIR define to reflect reality.
   
   Patch from RedHat rpm repositories. Original bug report:
   https://bugzilla.redhat.com/show_bug.cgi?id=1365321
   
   Closes: https://github.com/libxmp/xmp-cli/issues/27


2. read_config.c: define SYSCONFDIR as ".", if not already defined.
   
   Just to be safe. (and would help with cases where one might use
   standalone makefiles and not autotools.)
