### PR TITLE
Replace list.h undefined behavior with offsetof.

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -4,6 +4,8 @@
 #ifndef __LINUX_LIST_H
 #define __LINUX_LIST_H
 
+#include <stddef.h> /* offsetof */
+
 #ifdef _MSC_VER
 #define __inline__ __inline
 #endif
@@ -35,7 +37,7 @@ struct list_head {
 } while (0)
 
 /*
- * Insert a new entry between two known consecutive entries. 
+ * Insert a new entry between two known consecutive entries.
  *
  * This is only for internal list manipulation where we know
  * the prev/next entries already!
@@ -136,7 +138,7 @@ static __inline__ void list_splice(struct list_head *list, struct list_head *hea
  * @member:	the name of the list_struct within the struct.
  */
 #define list_entry(ptr, type, member) \
-	((type *)((char *)(ptr)-(size_t)(&((type *)0)->member)))
+	((type *)((char *)(ptr) - offsetof(type, member)))
 
 /**
  * list_for_each	-	iterate over a list


### PR DESCRIPTION
This patch updates the xmp-cli copy of list.h with the same fix applied here for libxmp: https://github.com/libxmp/libxmp/commit/91de55837f332fa41035555cedf615d06231568d. Despite mostly working and being supported by everything, the hand-rolled "offsetof" used in this file is technically considered undefined behavior due to containing a dereference of `NULL`. Since `offsetof` is ANSI C there's no reason not to use it here.