### PR TITLE
Fix out-of-bounds read of mod->xxs, constify xmp_module_info pointers.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -97,7 +97,7 @@ static int read_key(void)
 	return key;
 }
 
-static void change_sequence(xmp_context handle, struct xmp_module_info *mi, struct control *ctl, int i)
+static void change_sequence(xmp_context handle, const struct xmp_module_info *mi, struct control *ctl, int i)
 {
 	int seq = ctl->sequence;
 
@@ -126,7 +126,7 @@ static void change_sequence(xmp_context handle, struct xmp_module_info *mi, stru
  * ESC [ C - right arrow
  * ESC [ D - left arrow
  */
-void read_command(xmp_context handle, struct xmp_module_info *mi, struct control *ctl)
+void read_command(xmp_context handle, const struct xmp_module_info *mi, struct control *ctl)
 {
 	int cmd;
 

--- a/src/common.h
+++ b/src/common.h
@@ -89,17 +89,17 @@ int set_tty(void);
 int reset_tty(void);
 
 /* info */
-void info_mod(struct xmp_module_info *, int);
+void info_mod(const struct xmp_module_info *, int);
 void info_message(const char *, ...);
 void info_frame_init(void);
-void info_frame(struct xmp_module_info *, struct xmp_frame_info *, struct control *, int);
-void info_ins_smp(struct xmp_module_info *);
-void info_instruments(struct xmp_module_info *);
-void info_samples(struct xmp_module_info *);
-void info_comment(struct xmp_module_info *);
+void info_frame(const struct xmp_module_info *, const struct xmp_frame_info *, struct control *, int);
+void info_ins_smp(const struct xmp_module_info *);
+void info_instruments(const struct xmp_module_info *);
+void info_samples(const struct xmp_module_info *);
+void info_comment(const struct xmp_module_info *);
 void info_help(void);
 
 /* commands */
-void read_command(xmp_context, struct xmp_module_info *, struct control *);
+void read_command(xmp_context, const struct xmp_module_info *, struct control *);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -114,7 +114,7 @@ static void sigcont_handler(int sig)
 }
 #endif
 
-static void show_info(int what, struct xmp_module_info *mi, int mode)
+static void show_info(int what, const struct xmp_module_info *mi, int mode)
 {
 	report("\r%78.78s\n", " ");
 	switch (what) {
@@ -153,7 +153,7 @@ static void shuffle(int argc, char **argv)
 }
 
 static void check_pause(xmp_context xc, struct control *ctl,
-	struct xmp_module_info *mi, struct xmp_frame_info *fi, int verbose)
+	const struct xmp_module_info *mi, const struct xmp_frame_info *fi, int verbose)
 {
 	if (ctl->pause) {
 		sound->pause();


### PR DESCRIPTION
Fixes out-of-bounds reads of the libxmp samples array reported by @debrouxl here: https://github.com/libxmp/libxmp/pull/383

Also constifies most `xmp_module_info` pointers since the functions that use them are mostly for info reporting and have no business modifying its contents directly.