### PR TITLE
manpage: fix some incorrect documentation

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,6 @@ The following single key commands can be used during the playback:
             !         =>  unmute all channels
             ?         =>  display available commands
             X         =>  display current mixer type
-            x         =>  enable classic mixers
             Z         =>  display current sequence
             z         =>  toggle subsong explorer mode
             l         =>  toggle loop mode

--- a/src/xmp.1
+++ b/src/xmp.1
@@ -6,6 +6,7 @@ xmp - Extended Module Player
 .SH "SYNOPSIS" 
 \fBxmp\fP
 [\fB\-a, \-\-amplify\fP \fIfactor\fP]
+[\fB\-A, \-\-amiga\fP]
 [\fB\-b, \-\-bits\fP \fIbits\fP]
 [\fB\-C, \-\-show\-comments\fP]
 [\fB\-c, \-\-stdout\fP]
@@ -40,7 +41,6 @@ xmp - Extended Module Player
 [\fB\-\-vblank\fP]
 [\fB\-V, \-\-version\fP]
 [\fB\-v, \-\-verbose\fP]
-[\fB\-x, \-\-classic\fP]
 [\fB\-Z, \-\-all\-sequences\fP]
 [\fB\-z, \-\-sequence\fP \fInum\fP]
 \fImodules\fP
@@ -56,6 +56,8 @@ Scream Tracker 3 (S3M) and Impulse Tracker (IT)\&. Run
 Amplification factor for the software mixer\&. Valid amplification factors
 range from 0 to 3. Default is 1. \&. Warning\&: higher amplification
 factors may cause distorted or noisy output\&.
+.IP "\fB\-A, \-\-amiga\fP" 
+Use a mixer which models the sound of an Amiga 500\&, with or without the led filter\&.
 .IP "\fB\-b, \-\-bits\fP \fIbits\fP" 
 Set the software mixer resolution (8 or 16 bits)\&. If omitted,
 The audio device will be opened at the highest resolution available\&.
@@ -148,10 +150,6 @@ Print version information\&.
 Verbose mode (incremental)\&. If specified more than once, the
 verbosity level will be increased (no messages will be displayed
 when the player runs in background)\&.
-.IP "\fB\-x, \-\-classic\fP" 
-Use classic sound mixers\&, if available for the format being played\&.
-For Amiga formats such as Protracker, the classic mode mixer models the
-sound of an Amiga 500\&, with or without the led filter\&.
 .IP "\fB\-Z, \-\-all\-sequences\fP" 
 Play all hidden or alternative pattern sequences (subsongs) in module\&.
 .IP "\fB\-z, \-\-sequence\fP \fInum\fP" 

--- a/src/xmp.1
+++ b/src/xmp.1
@@ -231,8 +231,6 @@ Unmute all channels\&.
 Display available commands\&.
 .IP "\fBX\fP" 
 Display current mixer type\&.
-.IP "\fBx\fP" 
-Enable classic mixers (if available)\&.
 .IP "\fBZ\fP" 
 Display current sequence\&.
 .IP "\fBz\fP" 


### PR DESCRIPTION
There's incorrect documentation about a few options here, which confused me until I realized it didn't line up with what's in the source. This PR fixes them up. Namely:

* The manpage documents the `--classic` flag for using the classic mixers, and implies there might be non-Amiga options. The actual option is named `--amiga` and is Amiga-specific.
* The manpage and README both document a keyboard option to change the mixer at runtime, but that option doesn't seem to exist.