### PR TITLE
Improve detection of old BSD sound driver to fix OpenBSD builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,7 +250,7 @@ dnl Modern OpenBSD has sys/audioio.h but does not support this driver.
     AC_CHECK_MEMBER([audio_info_t.play],
       [ AC_DEFINE([SOUND_BSD], 1, [ ])
         AM_CONDITIONAL([SOUND_BSD], [true])
-      ], [ ], [[#include <sys/audioio.h>]])
+      ], , [[#include <sys/audioio.h>]])
   ])
   ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -245,9 +245,12 @@ beos*|haiku*)
   AM_CONDITIONAL([SOUND_BEOS], [true])
   ;;
 *)
+dnl Modern OpenBSD has sys/audioio.h but does not support this driver.
   AS_IF([test "$ac_cv_header_sys_audioio_h" = "yes"], [
-    AC_DEFINE([SOUND_BSD], 1, [ ])
-    AM_CONDITIONAL([SOUND_BSD], [true])
+    AC_CHECK_MEMBER([audio_info_t.play],
+      [ AC_DEFINE([SOUND_BSD], 1, [ ])
+        AM_CONDITIONAL([SOUND_BSD], [true])
+      ], [ ], [[#include <sys/audioio.h>]])
   ])
   ;;
 esac


### PR DESCRIPTION
At some point it seems OpenBSD dropped `audio_info_t` and its related functionality. This adds a check for `audio_info_t` so this driver won't be built for newer OpenBSD versions.