### PR TITLE
Fix NetBSD driver compile error and OSS link error.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,9 @@ netbsd*)
     AC_DEFINE(SOUND_NETBSD, 1, [ ])
     AM_CONDITIONAL([SOUND_NETBSD], [true])
   fi
+  if test "${ac_cv_header_sys_soundcard_h}" = "yes"; then
+    AC_CHECK_LIB(ossaudio, _oss_ioctl)
+  fi
   ;;
 solaris*)
   if test "${ac_cv_header_sys_audioio_h}" = "yes"; then

--- a/src/sound_netbsd.c
+++ b/src/sound_netbsd.c
@@ -101,7 +101,7 @@ static void play(void *b, int i)
 	while (i) {
 		if ((j = write(audio_fd, b, i)) > 0) {
 			i -= j;
-			(char *)b += j;
+			b = (char *)b + j;
 		} else
 			break;
 	}


### PR DESCRIPTION
I found two errors preventing NetBSD builds from working while testing #51:

* The NetBSD sound driver attempts to modify an rvalue, which presumably works in some compiler/standard or wasn't tested. NetBSD 9.2's GCC 7.5 emits an error instead.
* NetBSD requires `-lossaudio` to build the OSS driver, otherwise it will fail to link. This driver won't initialize for whatever reason, but at least it compiles now.

~~My VM is silent but plays back girl_from_mars.xm at the correct rate, so presumably the NetBSD driver works~~ It works, just had to switch the VM from AC'97 to Intel HD.