### PR TITLE
Use /dev/audio or pkgsrc DEVOSSAUDIO for OSS on NetBSD.

### DIFF
--- a/src/sound_netbsd.c
+++ b/src/sound_netbsd.c
@@ -36,7 +36,7 @@ static int init(struct options *options)
 	chkparm1("buffer", bsize = strtoul(token, NULL, 0));
 	parm_end();
 
-	if ((audio_fd = open("/dev/sound", O_WRONLY)) == -1)
+	if ((audio_fd = open("/dev/audio", O_WRONLY)) == -1)
 		return -1;
 
 	/* try to open audioctldevice */

--- a/src/sound_oss.c
+++ b/src/sound_oss.c
@@ -109,7 +109,14 @@ static void setaudio(int *rate, int *format)
 static int init(struct options *options)
 {
 	char **parm = options->driver_parm;
-	static const char *dev_audio[] = { "/dev/dsp", "/dev/sound/dsp" };
+	static const char *dev_audio[] = {
+#ifdef DEVOSSAUDIO
+		DEVOSSAUDIO,	/* pkgsrc */
+#endif
+		"/dev/dsp",
+		"/dev/sound/dsp",
+		"/dev/audio"	/* NetBSD and SunOS */
+	};
 	audio_buf_info info;
 	static char buf[80];
 	int i;


### PR DESCRIPTION
Port of two downstream pkgsrc patches.

* The NetBSD-specific OSS driver was referencing `/dev/sound` instead of `/dev/audio`. The other part of this patch was already independently fixed in #53. I don't know if this actually makes much of a difference, but `/dev/audio` seems to be the preferred one to use. http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/audio/xmp/patches/patch-src_drivers_netbsd.c?rev=1.4&content-type=text/x-cvsweb-markup
* The generic OSS driver enables by default for NetBSD but did not use the correct device for NetBSD. I added `/dev/audio` to the end of the device list, as well as a compile time enabled `DEVOSSAUDIO` for pkgsrc at the start of the device list. http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/audio/xmp/patches/patch-src_sound_oss.c?rev=1.1&content-type=text/x-cvsweb-markup

This fixes the generic OSS driver in my NetBSD 9.2 VM.

Combining the OSS, NetBSD, and Solaris drivers should probably at least be humored at some point, if possible.