### PR TITLE
replacing posix libc dependencies

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,7 @@ Stable versions
 	Changes by Emanuel Haupt:
 	- Make configure detect sndio on FreeBSD
 	Changes by Alice Rowan:
+	- Fix mod->xxs out-of-bounds read.
 	- Fix terminal output for MSYS2.
 	- Fix crash-on-exit in Windows audio output.
 	- Fixes to BSD audio output modules.

--- a/Changelog
+++ b/Changelog
@@ -3,16 +3,18 @@ Stable versions
 
 4.2.0 ():
 	Changes by Özkan Sezer:
-	- Fix libxmp detection in configuration script
-	- Fix OS/2 and Amiga builds
+	- Fix OS/2 and Amiga builds. OS-specific tweaks.
+	- DOS Sound Blaster output, adapted from mikmod.
 	- Build system improvements.
 	Changes by Emanuel Haupt:
 	- Make configure detect sndio on FreeBSD
 	Changes by Alice Rowan:
 	- Fix terminal output for MSYS2.
 	- Fix crash-on-exit in Windows audio output.
+	- Fixes to BSD audio output modules.
 	Changes by Cameron Cawley:
 	- Support compiling for Windows with OpenWatcom.
+	- DOS Sound Blaster support using OpenWatcom.
 
 4.1.0 (20160719):
 	- Requires libxmp 4.4

--- a/Makefile.dos
+++ b/Makefile.dos
@@ -19,7 +19,7 @@ CFLAGS += -wcd=303
 # -5s  :  Pentium stack calling conventions.
 # -5r  :  Pentium register calling conventions.
 CFLAGS += -5s
-INCLUDES = -I"src/watcom" -I"$(%WATCOM)/h"
+INCLUDES = -I"$(%WATCOM)/h"
 
 # for sound_sb:
 CPPFLAGS+= -DSOUND_SB

--- a/Makefile.os2
+++ b/Makefile.os2
@@ -23,7 +23,7 @@ CFLAGS += -wcd=303
 # -5s  :  Pentium stack calling conventions.
 # -5r  :  Pentium register calling conventions.
 CFLAGS += -5s
-INCLUDES = -I"src/watcom" -I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
+INCLUDES = -I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 
 # for sound_dart:
 CPPFLAGS = -DSOUND_OS2DART

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -23,7 +23,7 @@ CFLAGS += -wcd=303
 # -5s  :  Pentium stack calling conventions.
 # -5r  :  Pentium register calling conventions.
 CFLAGS += -5s
-INCLUDES = -I"src/win32" -I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
+INCLUDES = -I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
 
 # for sound_win32:
 CPPFLAGS = -DSOUND_WIN32

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_DEFUN([AC_CHECK_DEFINED],[
   AS_VAR_POPDEF([ac_var])dnl
 ])
 
-AC_CHECK_HEADERS([getopt.h signal.h sys/select.h sys/time.h sys/audioio.h])
+AC_CHECK_HEADERS([sys/types.h unistd.h getopt.h signal.h sys/select.h sys/time.h sys/audioio.h])
 case $host_os in
 dnl don't check half-baked termios for amiga or dos targets.
   amigaos*|aros*|morphos*|*djgpp) ;;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,5 +100,4 @@ pkgsysconfdir   = ${sysconfdir}/${PACKAGE_NAME}
 pkgsysconf_DATA = modules.conf xmp.conf
 
 EXTRA_DIST = ${man_MANS} ${pkgsysconf_DATA} \
-	dos/dosdma.h dos/dosirq.h dos/dossb.h dos/dosutil.h \
-	win32/unistd.h watcom/unistd.h
+	dos/dosdma.h dos/dosirq.h dos/dossb.h dos/dosutil.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ bin_PROGRAMS = xmp
 xmp_SOURCES = \
 	commands.c common.h delay.c getopt_long.h list.h getopt_long.c info.c \
 	main.c options.c read_config.c sound.c sound.h sound_file.c sound_null.c \
-	sound_wav.c sound_aiff.c terminal.c xmp_version.h
+	sound_wav.c sound_aiff.c terminal.c util.c xmp_version.h
 xmp_LDADD   = ${LIBXMP_LIBS}
 xmp_LDFLAGS = ${XMP_DARWIN_LDFLAGS}
 
@@ -90,7 +90,6 @@ endif
 
 if SOUND_OS2DART
 xmp_SOURCES += sound_dart.c
-# for mciSendCommand()
 xmp_LDADD   += -lmmpm2
 endif
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -67,12 +67,7 @@ static int read_key(void)
 	char key;
 	int ret = 0;
 
-#if defined(HAVE_TERMIOS_H) && !(defined(_WIN32) || defined(__DJGPP__) || defined(_DOS))
-#ifdef __CYGWIN__
-	if (stdin_ready_for_reading())
-#endif
-		ret = read(0, &key, 1);
-#elif defined(_WIN32) || defined(__OS2__) || defined(__DJGPP__) || defined(_DOS)
+#if defined(_WIN32) || defined(__OS2__) || defined(__DJGPP__) || defined(_DOS)
 	if (kbhit()) {
 		key = getch();
 		ret = 1;
@@ -86,6 +81,11 @@ static int read_key(void)
 			ret = 1;
 		}
 	}
+#elif defined(HAVE_TERMIOS_H))
+#ifdef __CYGWIN__
+	if (stdin_ready_for_reading())
+#endif
+		ret = read(0, &key, 1);
 #else
 	ret = 0;
 #endif

--- a/src/commands.c
+++ b/src/commands.c
@@ -6,7 +6,6 @@
  * file for more information.
  */
 
-#include <xmp.h>
 #include "common.h"
 
 #if defined(_WIN32) || defined(__OS2__) || defined(__DJGPP__) || defined(_DOS)
@@ -86,10 +85,10 @@ static int read_key(void)
 		}
 	}
 #elif defined(HAVE_TERMIOS_H)
-#ifdef __CYGWIN__
+	#ifdef __CYGWIN__
 	if (stdin_ready_for_reading())
-#endif
-		ret = read(0, &key, 1);
+	#endif
+	    ret = read(0, &key, 1);
 #else
 	ret = 0;
 #endif

--- a/src/commands.c
+++ b/src/commands.c
@@ -6,10 +6,13 @@
  * file for more information.
  */
 
-#include <unistd.h>
+#include <xmp.h>
+#include "common.h"
+
 #if defined(_WIN32) || defined(__OS2__) || defined(__DJGPP__) || defined(_DOS)
 #include <conio.h>
 #endif
+
 #if defined(XMP_AMIGA)
 #ifdef __amigaos4__
 #define __USE_INLINE__
@@ -17,8 +20,10 @@
 #include <proto/exec.h>
 #include <proto/dos.h>
 #endif
-#include <xmp.h>
-#include "common.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 #ifdef __CYGWIN__
 #include <sys/select.h>

--- a/src/commands.c
+++ b/src/commands.c
@@ -10,7 +10,7 @@
 #if defined(_WIN32) || defined(__OS2__) || defined(__DJGPP__) || defined(_DOS)
 #include <conio.h>
 #endif
-#if defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#if defined(XMP_AMIGA)
 #ifdef __amigaos4__
 #define __USE_INLINE__
 #endif
@@ -22,7 +22,6 @@
 
 #ifdef __CYGWIN__
 #include <sys/select.h>
-
 /*
  * from	daniel åkerud <daniel.akerud@gmail.com>
  * date	Tue, Jul 28, 2009 at 9:59 AM
@@ -36,7 +35,7 @@
  * typed out when running xmp. I have not investigated why this is
  * happening, but there is of course a reason why this mode is not
  * enabled by default.
- * 
+ *
  * 2. Do a select() before read()ing if the platform is Cygwin.
  * This makes Cygwin builds work out of the box with no fiddling around,
  * but does impose a neglectible cpu overhead (for Cygwin builds only).
@@ -72,7 +71,7 @@ static int read_key(void)
 		key = getch();
 		ret = 1;
 	}
-#elif defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#elif defined(XMP_AMIGA)
 	/* Amiga CLI */
 	{
 		BPTR in = Input();

--- a/src/commands.c
+++ b/src/commands.c
@@ -81,7 +81,7 @@ static int read_key(void)
 			ret = 1;
 		}
 	}
-#elif defined(HAVE_TERMIOS_H))
+#elif defined(HAVE_TERMIOS_H)
 #ifdef __CYGWIN__
 	if (stdin_ready_for_reading())
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -78,7 +78,7 @@ extern struct player_mode pmode[];
 
 int report(const char *, ...);
 
-void delay_ms(int msec);
+void delay_ms(unsigned int msec);
 
 char *xmp_strdup(const char *);
 int xmp_strcasecmp(const char *, const char *); /* locale-insensitive */

--- a/src/common.h
+++ b/src/common.h
@@ -79,6 +79,10 @@ extern struct player_mode pmode[];
 int report(const char *, ...);
 
 void delay_ms(unsigned int msec);
+#ifdef XMP_AMIGA
+void amiga_inittimer(void);
+void amiga_getsystime(void *);
+#endif
 
 char *xmp_strdup(const char *);
 int xmp_strcasecmp(const char *, const char *); /* locale-insensitive */

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,6 @@
 #ifndef __cplusplus
 #define inline __inline
 #endif
-#define strdup _strdup
 #define strcasecmp _stricmp
 #define snprintf _snprintf
 #define kbhit _kbhit
@@ -76,6 +75,8 @@ extern struct player_mode pmode[];
 int report(const char *, ...);
 
 void delay_ms(int msec);
+
+char *xmp_strdup(const char *);
 
 /* option */
 void get_options(int, char **, struct options *);

--- a/src/common.h
+++ b/src/common.h
@@ -19,6 +19,9 @@
 #define NUM_MODES 13
 #define MAX_DRV_PARM 20
 
+
+#include <xmp.h>
+
 struct player_mode {
 	const char *name;
 	const char *desc;

--- a/src/common.h
+++ b/src/common.h
@@ -6,10 +6,6 @@
 #ifndef __cplusplus
 #define inline __inline
 #endif
-#define open _open
-#define close _close
-#define write _write
-#define lseek _lseek
 #define strdup _strdup
 #define strcasecmp _stricmp
 #define snprintf _snprintf

--- a/src/common.h
+++ b/src/common.h
@@ -11,6 +11,11 @@
 #define getch _getch
 #endif
 
+#if defined(__MORPHOS__) || defined(__AROS__) || defined(__AMIGA__) \
+ || defined(__amigaos__) || defined(__amigaos4__) || defined(AMIGA)
+#define XMP_AMIGA	1
+#endif
+
 #define NUM_MODES 13
 #define MAX_DRV_PARM 20
 

--- a/src/common.h
+++ b/src/common.h
@@ -2,11 +2,11 @@
 #define XMP_COMMON_H
 
 #ifdef _MSC_VER
-#define PATH_MAX 1024
 #ifndef __cplusplus
 #define inline __inline
 #endif
 #define snprintf _snprintf
+#define vsnprintf _vsnprintf
 #define kbhit _kbhit
 #define getch _getch
 #endif
@@ -81,7 +81,7 @@ extern struct player_mode pmode[];
 
 int report(const char *, ...);
 
-void delay_ms(unsigned int msec);
+void delay_ms(unsigned int);
 #ifdef XMP_AMIGA
 void amiga_inittimer(void);
 void amiga_getsystime(void *);

--- a/src/common.h
+++ b/src/common.h
@@ -79,8 +79,6 @@ struct control {
 
 extern struct player_mode pmode[];
 
-int report(const char *, ...);
-
 void delay_ms(unsigned int);
 #ifdef XMP_AMIGA
 void amiga_inittimer(void);
@@ -89,6 +87,7 @@ void amiga_getsystime(void *);
 
 char *xmp_strdup(const char *);
 int xmp_strcasecmp(const char *, const char *); /* locale-insensitive */
+int report(const char *, ...);
 
 /* option */
 void get_options(int, char **, struct options *);

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,6 @@
 #ifndef __cplusplus
 #define inline __inline
 #endif
-#define strcasecmp _stricmp
 #define snprintf _snprintf
 #define kbhit _kbhit
 #define getch _getch
@@ -77,6 +76,7 @@ int report(const char *, ...);
 void delay_ms(int msec);
 
 char *xmp_strdup(const char *);
+int xmp_strcasecmp(const char *, const char *); /* locale-insensitive */
 
 /* option */
 void get_options(int, char **, struct options *);

--- a/src/delay.c
+++ b/src/delay.c
@@ -6,7 +6,6 @@
  * file for more information.
  */
 
-#include <xmp.h>
 #include "common.h"
 
 #if defined(_WIN32)

--- a/src/delay.c
+++ b/src/delay.c
@@ -13,7 +13,7 @@ void delay_ms(int msec) {
 	Sleep(msec);
 }
 
-#elif defined(__OS2__)
+#elif defined(__OS2__)||defined(__EMX__)
 #define INCL_DOSPROCESS
 #include <os2.h>
 
@@ -40,9 +40,15 @@ void delay_ms(int msec) {
 #ifdef HAVE_SYS_SELECT_H
 #  include <sys/select.h>
 #else
+#  ifdef HAVE_SYS_TIME_H
 #  include <sys/time.h>
+#  endif
+#  ifdef HAVE_SYS_TYPES_H
 #  include <sys/types.h>
+#  endif
+#  ifdef HAVE_UNISTD_H
 #  include <unistd.h>
+#  endif
 #endif
 #include <stddef.h>
 

--- a/src/delay.c
+++ b/src/delay.c
@@ -9,7 +9,7 @@
 #if defined(_WIN32)
 #include <windows.h>
 
-void delay_ms(int msec) {
+void delay_ms(unsigned int msec) {
 	Sleep(msec);
 }
 
@@ -17,21 +17,21 @@ void delay_ms(int msec) {
 #define INCL_DOSPROCESS
 #include <os2.h>
 
-void delay_ms(int msec) {
+void delay_ms(unsigned int msec) {
 	DosSleep(msec);
 }
 
 #elif defined(_DOS)
 #include <dos.h>
 
-void delay_ms(int msec) {
+void delay_ms(unsigned int msec) {
 	delay(msec); /* doesn't seem to use int 15h. */
 }
 
 #elif defined(HAVE_USLEEP)
 #include <unistd.h>
 
-void delay_ms(int msec) {
+void delay_ms(unsigned int msec) {
 	usleep(msec * 1000);
 }
 
@@ -52,7 +52,7 @@ void delay_ms(int msec) {
 #endif
 #include <stddef.h>
 
-void delay_ms(int msec) {
+void delay_ms(unsigned int msec) {
 	struct timeval tv;
 	long usec;
 

--- a/src/info.c
+++ b/src/info.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-#include <xmp.h>
+
 #include "common.h"
 
 static int max_channels = -1;

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,15 @@ static struct sound_driver *sound;
 static unsigned int foreground_in, foreground_out;
 static int refresh_status;
 
+char *xmp_strdup(const char *in)
+{
+	size_t len = strlen(in) + 1;
+	char *out = (char *) malloc(len);
+	if (out) {
+		memcpy(out, in, len);
+	}
+	return out;
+}
 
 int report(const char *fmt, ...)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -655,5 +655,5 @@ int main(int argc, char **argv)
 
 	sound->deinit();
 
-	exit(EXIT_SUCCESS);
+	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -44,16 +44,6 @@ static struct sound_driver *sound;
 static unsigned int foreground_in, foreground_out;
 static int refresh_status;
 
-char *xmp_strdup(const char *in)
-{
-	size_t len = strlen(in) + 1;
-	char *out = (char *) malloc(len);
-	if (out) {
-		memcpy(out, in, len);
-	}
-	return out;
-}
-
 int report(const char *fmt, ...)
 {
 	va_list a;

--- a/src/main.c
+++ b/src/main.c
@@ -6,8 +6,8 @@
  * file for more information.
  */
 
-#include <xmp.h>
 #include "common.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -36,7 +36,8 @@
 #else
 #include "getopt_long.h"
 #endif
-#include "errno.h"
+#include <errno.h>
+
 #include "sound.h"
 #include "xmp_version.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,8 +18,12 @@
 #if defined(__WATCOMC__)
 #include <time.h>
 #endif
+#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
+#endif
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <stdarg.h>
 #if defined(HAVE_GETOPT_H) && defined(HAVE_GETOPT_LONG)
 #include <getopt.h>

--- a/src/main.c
+++ b/src/main.c
@@ -49,18 +49,6 @@ static struct sound_driver *sound;
 static unsigned int foreground_in, foreground_out;
 static int refresh_status;
 
-int report(const char *fmt, ...)
-{
-	va_list a;
-	int n;
-
-	va_start(a, fmt);
-	n = vfprintf(stderr, fmt, a);
-	va_end(a);
-
-	return n;
-}
-
 #ifdef HAVE_SIGNAL_H
 static void cleanup(int sig)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,8 @@
  * file for more information.
  */
 
+#include <xmp.h>
+#include "common.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,6 +16,10 @@
 #endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
+#if defined(XMP_AMIGA)
+#include <proto/timer.h>
+#include <time.h>
 #endif
 #if defined(__WATCOMC__)
 #include <time.h>
@@ -30,10 +36,8 @@
 #else
 #include "getopt_long.h"
 #endif
-#include <xmp.h>
 #include "errno.h"
 #include "sound.h"
-#include "common.h"
 #include "xmp_version.h"
 
 #ifdef _WIN32
@@ -260,6 +264,16 @@ int main(int argc, char **argv)
 	srand(GetTickCount());
 #elif defined(__WATCOMC__)
 	srand(time(NULL));
+#elif defined(__amigaos4__)
+	struct TimeVal tv;
+	amiga_inittimer();
+	amiga_getsystime(&tv);
+	srand(tv.Microseconds);
+#elif defined(XMP_AMIGA)
+	struct timeval tv;
+	amiga_inittimer();
+	amiga_getsystime(&tv);
+	srand(tv.tv_micro);
 #else
 	struct timeval tv;
 	gettimeofday(&tv, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,7 @@ static void sigcont_handler(int sig)
 	}
 #else
 	foreground_in = foreground_out = 1;
-	#if defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+	#if defined(XMP_AMIGA)
 	set_tty();	/* amiga version -- sets stdin to raw mode. */
 	#endif
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -262,9 +262,7 @@ int main(int argc, char **argv)
 	srand(time(NULL));
 #else
 	struct timeval tv;
-	struct timezone tz;
-
-	gettimeofday(&tv, &tz);
+	gettimeofday(&tv, NULL);
 	srand(tv.tv_usec);
 #endif
 

--- a/src/options.c
+++ b/src/options.c
@@ -23,8 +23,6 @@
 #include "getopt_long.h"
 #endif
 
-#include <xmp.h>
-
 #include "common.h"
 #include "sound.h"
 #include "list.h"

--- a/src/options.c
+++ b/src/options.c
@@ -13,12 +13,16 @@
 #include <strings.h>
 #endif
 #include <stdlib.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+
 #if defined(HAVE_GETOPT_H) && defined(HAVE_GETOPT_LONG)
 #include <getopt.h>
 #else
 #include "getopt_long.h"
 #endif
+
 #include <xmp.h>
 
 #include "common.h"

--- a/src/options.c
+++ b/src/options.c
@@ -283,10 +283,10 @@ void get_options(int argc, char **argv, struct options *options)
 		case 'o':
 			options->out_file = optarg;
 			if (strlen(optarg) >= 4 &&
-			    !strcasecmp(optarg + strlen(optarg) - 4, ".wav")) {
+			    !xmp_strcasecmp(optarg + strlen(optarg) - 4, ".wav")) {
 				options->driver_id = "wav";
 			} else if (strlen(optarg) >= 5 &&
-			    !strcasecmp(optarg + strlen(optarg) - 5, ".aiff")) {
+			    !xmp_strcasecmp(optarg + strlen(optarg) - 5, ".aiff")) {
 				options->driver_id = "aiff";
 			} else {
 				options->driver_id = "file";

--- a/src/options.c
+++ b/src/options.c
@@ -6,16 +6,8 @@
  * file for more information.
  */
 
-#include <stdio.h>
-#include <ctype.h>
 #include <string.h>
-#ifdef HAVE_STRINGS_H
-#include <strings.h>
-#endif
 #include <stdlib.h>
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 
 #if defined(HAVE_GETOPT_H) && defined(HAVE_GETOPT_LONG)
 #include <getopt.h>

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -17,6 +17,10 @@
 #define SYSCONFDIR "."
 #endif
 
+#if defined(XMP_AMIGA) && !defined(PATH_MAX)	/* e.g.: vbcc headers */
+#define PATH_MAX 1024
+#endif
+
 static char driver[32];
 static char instrument_path[256];
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <xmp.h>
+
 #include "common.h"
 
 #if !defined(SYSCONFDIR)

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -164,7 +164,7 @@ int read_config(struct options *o)
 		 */
 		if (o->dparm < MAX_DRV_PARM) {
 			snprintf(cparm, 512, "%s=%s", var, val);
-			o->driver_parm[o->dparm++] = strdup(cparm);
+			o->driver_parm[o->dparm++] = xmp_strdup(cparm);
 		}
 	}
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -54,7 +54,7 @@ int read_config(struct options *o)
 			return -1;
 		}
 	}
-#elif defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#elif defined(XMP_AMIGA)
 	strncpy(myrc, "PROGDIR:xmp.conf", PATH_MAX);
 
 	if ((rc = fopen(myrc, "r")) == NULL)
@@ -291,7 +291,7 @@ void read_modconf(struct options *o, const unsigned char *md5)
 	snprintf(myrc, PATH_MAX, "%s\\modules.conf", home);
 	parse_modconf(o, "xmp-modules.conf", md5);
 	parse_modconf(o, myrc, md5);
-#elif defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#elif defined(XMP_AMIGA)
 	parse_modconf(o, "PROGDIR:modules.conf", md5);
 #elif defined _WIN32
 	char myrc[PATH_MAX];

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -17,8 +17,12 @@
 #define SYSCONFDIR "."
 #endif
 
-#if defined(XMP_AMIGA) && !defined(PATH_MAX)	/* e.g.: vbcc headers */
-#define PATH_MAX 1024
+#if defined(_MSC_VER) ||  defined(__WATCOMC__) || defined(__EMX__)
+#define XMP_MAXPATH _MAX_PATH
+#elif defined(PATH_MAX)
+#define XMP_MAXPATH  PATH_MAX
+#else
+#define XMP_MAXPATH  1024
 #endif
 
 static char driver[32];
@@ -43,7 +47,7 @@ static int get_yesno(char *s)
 int read_config(struct options *o)
 {
 	FILE *rc;
-	char myrc[PATH_MAX];
+	char myrc[XMP_MAXPATH];
 	char *hash, *var, *val, line[256];
 	char cparm[512];
 
@@ -51,7 +55,7 @@ int read_config(struct options *o)
 	const char *home = getenv("HOME");
 	if (!home) home = "C:";
 
-	snprintf(myrc, PATH_MAX, "%s\\xmp.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s\\xmp.conf", home);
 
 	if ((rc = fopen(myrc, "r")) == NULL) {
 		if ((rc = fopen("xmp.conf", "r")) == NULL) {
@@ -59,7 +63,7 @@ int read_config(struct options *o)
 		}
 	}
 #elif defined(XMP_AMIGA)
-	strncpy(myrc, "PROGDIR:xmp.conf", PATH_MAX);
+	strncpy(myrc, "PROGDIR:xmp.conf", XMP_MAXPATH);
 
 	if ((rc = fopen(myrc, "r")) == NULL)
 		return -1;
@@ -67,17 +71,17 @@ int read_config(struct options *o)
 	const char *home = getenv("USERPROFILE");
 	if (!home) home = "C:";
 
-	snprintf(myrc, PATH_MAX, "%s/xmp.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s/xmp.conf", home);
 
 	if ((rc = fopen(myrc, "r")) == NULL)
 		return -1;
 #else
 	char *home = getenv("HOME");
 
-	snprintf(myrc, PATH_MAX, "%s/.xmp/xmp.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s/.xmp/xmp.conf", home);
 
 	if ((rc = fopen(myrc, "r")) == NULL) {
-		strncpy(myrc, SYSCONFDIR "/xmp.conf", PATH_MAX);
+		strncpy(myrc, SYSCONFDIR "/xmp.conf", XMP_MAXPATH);
 		if ((rc = fopen(myrc, "r")) == NULL) {
 			return -1;
 		}
@@ -288,27 +292,27 @@ static void parse_modconf(struct options *o, const char *confname, const unsigne
 void read_modconf(struct options *o, const unsigned char *md5)
 {
 #if defined(__OS2__) || defined(__EMX__)
-	char myrc[PATH_MAX];
+	char myrc[XMP_MAXPATH];
 	const char *home = getenv("HOME");
 	if (!home) home = "C:";
 
-	snprintf(myrc, PATH_MAX, "%s\\modules.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s\\modules.conf", home);
 	parse_modconf(o, "xmp-modules.conf", md5);
 	parse_modconf(o, myrc, md5);
 #elif defined(XMP_AMIGA)
 	parse_modconf(o, "PROGDIR:modules.conf", md5);
 #elif defined _WIN32
-	char myrc[PATH_MAX];
+	char myrc[XMP_MAXPATH];
 	const char *home = getenv("USERPROFILE");
 	if (!home) home = "C:";
 
-	snprintf(myrc, PATH_MAX, "%s/modules.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s/modules.conf", home);
 	parse_modconf(o, myrc, md5);
 #else
-	char myrc[PATH_MAX];
+	char myrc[XMP_MAXPATH];
 	char *home = getenv("HOME");
 
-	snprintf(myrc, PATH_MAX, "%s/.xmp/modules.conf", home);
+	snprintf(myrc, XMP_MAXPATH, "%s/.xmp/modules.conf", home);
 	parse_modconf(o, SYSCONFDIR "/modules.conf", md5);
 	parse_modconf(o, myrc, md5);
 #endif

--- a/src/sound.h
+++ b/src/sound.h
@@ -1,8 +1,8 @@
 #ifndef XMP_SOUND_H
 #define XMP_SOUND_H
 
-#include <xmp.h>
 #include <stdio.h>
+
 #include "common.h"
 #include "list.h"
 

--- a/src/sound_beos.cpp
+++ b/src/sound_beos.cpp
@@ -15,7 +15,6 @@
 extern "C" {
 #include <string.h>
 #include <stdlib.h>
-#include "xmp.h"
 #include "sound.h"
 }
 
@@ -173,7 +172,7 @@ static void play(void *b, int i)
 		snooze(100000);
 
 	while (i) {
-        	if ((j = write_buffer((uint8 *)b, i)) > 0) {
+		if ((j = write_buffer((uint8 *)b, i)) > 0) {
 			i -= j;
 			b = (uint8 *)b + j;
 		} else {

--- a/src/sound_file.c
+++ b/src/sound_file.c
@@ -49,7 +49,7 @@ static int init(struct options *options)
 						options->out_file);
 		sound_file.description = buf;
 	} else {
-		sound_file.description = strdup("stdout");
+		sound_file.description = xmp_strdup("stdout");
 	}
 
 	return 0;

--- a/src/sound_wav.c
+++ b/src/sound_wav.c
@@ -76,7 +76,7 @@ static int init(struct options *options)
 						options->out_file);
 		sound_wav.description = buf;
 	} else {
-		sound_wav.description = strdup("WAV writer: stdout");
+		sound_wav.description = xmp_strdup("WAV writer: stdout");
 		len = -1;
 	}
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -10,7 +10,7 @@
 #include <xmp.h>
 #include "common.h"
 
-#if defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#if defined(XMP_AMIGA)
 #ifdef __amigaos4__
 #define __USE_INLINE__
 #endif
@@ -29,7 +29,7 @@ static struct termios term;
 
 int set_tty(void)
 {
-#if defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#if defined(XMP_AMIGA)
 	SetMode(Input(), MODE_RAW);
 
 #elif defined HAVE_TERMIOS_H
@@ -53,7 +53,7 @@ int set_tty(void)
 
 int reset_tty(void)
 {
-#if defined(AMIGA) || defined(__AMIGA__) || defined(__AROS__)
+#if defined(XMP_AMIGA)
 	SetMode(Input(), MODE_NORMAL);
 
 #elif defined HAVE_TERMIOS_H

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -6,9 +6,8 @@
  * file for more information.
  */
 
-#include <stdio.h>
-#include <xmp.h>
 #include "common.h"
+#include <stdio.h>
 
 #if defined(XMP_AMIGA)
 #ifdef __amigaos4__

--- a/src/util.c
+++ b/src/util.c
@@ -9,7 +9,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <xmp.h>
+
 #include "common.h"
 
 char *xmp_strdup(const char *in)
@@ -23,7 +23,7 @@ char *xmp_strdup(const char *in)
 }
 
 
-/* locale-insensitive tolower and strcasecmp : */
+/* locale-insensitive tolower and strcasecmp: */
 
 static inline int xmp_tolower(int c)
 {
@@ -49,4 +49,3 @@ int xmp_strcasecmp(const char *s1, const char *s2)
 
 	return (int)(c1 - c2);
 }
-

--- a/src/util.c
+++ b/src/util.c
@@ -22,3 +22,31 @@ char *xmp_strdup(const char *in)
 	return out;
 }
 
+
+/* locale-insensitive tolower and strcasecmp : */
+
+static inline int xmp_tolower(int c)
+{
+	return (c >= 'A' && c <= 'Z') ? (c | ('a' - 'A')) : c;
+}
+
+int xmp_strcasecmp(const char *s1, const char *s2)
+{
+	const char *p1 = s1;
+	const char *p2 = s2;
+	char c1, c2;
+
+	if (p1 == p2)
+		return 0;
+
+	do
+	{
+		c1 = xmp_tolower (*p1++);
+		c2 = xmp_tolower (*p2++);
+		if (c1 == '\0')
+			break;
+	} while (c1 == c2);
+
+	return (int)(c1 - c2);
+}
+

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,24 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * This file is part of the Extended Module Player and is distributed
+ * under the terms of the GNU General Public License. See the COPYING
+ * file for more information.
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xmp.h>
+#include "common.h"
+
+char *xmp_strdup(const char *in)
+{
+	size_t len = strlen(in) + 1;
+	char *out = (char *) malloc(len);
+	if (out) {
+		memcpy(out, in, len);
+	}
+	return out;
+}
+

--- a/src/util.c
+++ b/src/util.c
@@ -7,8 +7,10 @@
  */
 
 #include <stddef.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #include "common.h"
 
@@ -48,4 +50,17 @@ int xmp_strcasecmp(const char *s1, const char *s2)
 	} while (c1 == c2);
 
 	return (int)(c1 - c2);
+}
+
+
+int report(const char *fmt, ...)
+{
+	va_list a;
+	int n;
+
+	va_start(a, fmt);
+	n = vfprintf(stderr, fmt, a);
+	va_end(a);
+
+	return n;
 }

--- a/src/watcom/unistd.h
+++ b/src/watcom/unistd.h
@@ -1,6 +1,0 @@
-#ifndef XMP_WATCOM_UNISTD_H
-#define XMP_WATCOM_UNISTD_H
-
-#include <io.h>  /* do not want Watcom unistd.h */
-
-#endif

--- a/src/win32/unistd.h
+++ b/src/win32/unistd.h
@@ -1,6 +1,0 @@
-#ifndef _XMP_WIN32_UNISTD_H
-#define _XMP_WIN32_UNISTD_H
-
-#include <io.h>
-
-#endif

--- a/vc/xmp.vcproj
+++ b/vc/xmp.vcproj
@@ -38,7 +38,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="..\src;..\src\win32"
+				AdditionalIncludeDirectories="..\src"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;SOUND_WIN32"
 				ExceptionHandling="0"
 				RuntimeLibrary="2"

--- a/vc/xmp.vcproj
+++ b/vc/xmp.vcproj
@@ -163,6 +163,10 @@
 				RelativePath="..\src\terminal.c"
 				>
 			</File>
+			<File
+				RelativePath="..\src\util.c"
+				>
+			</File>
 		</Filter>
 	</Files>
 	<Globals>

--- a/watcom.mif
+++ b/watcom.mif
@@ -16,7 +16,7 @@ LIBS+= $(LIBXMP)
 AOUT=xmp.exe
 COMPILE=$(CC) $(CFLAGS) $(CPPFLAGS) $(INCLUDES)
 
-OBJ = commands.obj delay.obj getopt_long.obj info.obj main.obj options.obj read_config.obj sound.obj sound_aiff.obj sound_file.obj sound_null.obj sound_wav.obj terminal.obj
+OBJ = commands.obj delay.obj getopt_long.obj info.obj main.obj options.obj read_config.obj sound.obj sound_aiff.obj sound_file.obj sound_null.obj sound_wav.obj terminal.obj util.obj
 
 all: $(AOUT)
 


### PR DESCRIPTION
This is rather a draft for now: main goal is to replace unnecessary
posix libc dependencies with ansi or os-specific code.

The first attempt, i.e. the first patch here replaces posix file io
in wav, aiff, and raw output modules with ansi stdio: please review
carefully.
- is the lseek -> fseek conversion satisfactory?
- the local variable `len` sound_wav.c:init() is shadowed down below
  in the procedure (not because of this patch.)

The next attempt would be removing / conditionalizing sys/types.h and
unistd.h includes, replacing posix usleep / gettimeofday in the amiga
code, etc.
