### PR TITLE
Fix stdout output to support specified driver, and add loop-until feature

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -39,6 +39,7 @@ struct options {
 	int interp;		/* interpolation type */
 	int dsp;		/* dsp effects */
 	int loop;		/* loop module */
+	int loop_time;		/* loop until time */
 	int random;		/* play in random order */
 	int reverse;		/* reverse stereo channels */
 	int vblank;		/* vblank flag */

--- a/src/main.c
+++ b/src/main.c
@@ -529,7 +529,7 @@ int main(int argc, char **argv)
     play_sequence:
 			while (!opt.info && xmp_play_frame(xc) == 0) {
 				int old_loop = fi.loop_count;
-				
+
 				xmp_get_frame_info(xc, &fi);
 				control.mixer_type = xmp_get_player(
 						xc, XMP_PLAYER_MIXER_TYPE);
@@ -537,7 +537,9 @@ int main(int argc, char **argv)
 				/* Check loop */
 
 				if (old_loop != fi.loop_count) {
-					if (control.loop == 1) {
+					if (control.loop == 1 ||
+					    (opt.loop_time > 0 &&
+					     control.time < opt.loop_time)) {
 						info_message("Loop sequence %d", control.sequence);
 					} else {
 						break;


### PR DESCRIPTION
Fixes #60 and is at least a possible fix for #14. Both of these changes help with using xmp-cli as a streaming broadcast decoder:

The `-c` and `-o` options now cache off the output driver as a "guess" instead of forcing things, and then only applies it to `driver_id` if the user didn't explicitly specify one via `-d`. The idea is to allow the user to output a specific audio format to stdout instead of just raw bytes.

A `-U` / `--loop-until` option now allows looping to occur until playtime has reached the specified number of seconds. The idea is to allow short loopable mods to play for a bit longer before moving on, so that they don't blow by too quickly in a playlist.

Specific code changes:
- common.h:
  - add loop_time to struct options
- main.c:
  - allow loop if loop_time defined and playtime has not exceeded it
- options.c:
  - add "loop-until" feature
  - change '-c' and '-o' logic to record output driver as a "guess" that only gets applied if no driver is explicitly specified