### PR TITLE
Output the module size as part of the module info

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -61,7 +61,8 @@ void info_mod(const struct xmp_module_info *mi, int mode)
 		}
 	}
 
-	report("\nModule length: %d patterns\n", mi->mod->len);
+	report("\nModule size  : %d bytes (%d KB)\n", mi->size, (mi->size + 1023) / 1024);
+	report("Module length: %d patterns\n", mi->mod->len);
 	report("Patterns     : %d\n", mi->mod->pat);
 	report("Instruments  : %d\n", mi->mod->ins);
 	report("Samples      : %d\n", mi->mod->smp);


### PR DESCRIPTION
The size is reported both in bytes like e.g. `ocp` does, and in KBs like `openmpt123` does.

This requires the libxmp version bump I mentioned in [the PR](https://github.com/libxmp/libxmp/pull/708) I've just sent, but for the same reason, I'll let you maintainers do it, unless you want me to.