### PR TITLE
change sound_driver description into a driver specific function call

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -335,7 +335,7 @@ int main(int argc, char **argv)
 		report("Extended Module Player " VERSION "\n"
 			"Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr\n");
 
-		report("Using %s\n", sound->description);
+		report("Using %s\n", sound->description());
 
 		report("Mixer set to %d Hz, %dbit, %s%s%s\n", opt.rate,
 		    opt.format & XMP_FORMAT_8BIT ? 8 : 16,

--- a/src/options.c
+++ b/src/options.c
@@ -59,13 +59,13 @@ static void usage(char *s, struct options *options)
 
 	for (i = 0; sound_driver_list[i] != NULL; i++) {
 		sd = sound_driver_list[i];
-		printf("    %s (%s)\n", sd->id, sd->description);
+		printf("    %s (%s)\n", sd->id, sd->description());
 	}
 
 	for (i = 0; sound_driver_list[i] != NULL; i++) {
 		sd = sound_driver_list[i];
 		if (sd->help)
-			printf("\n%s options:\n", sd->description);
+			printf("\n%s options:\n", sd->description());
 		for (hlp = sd->help; hlp && *hlp; hlp += 2)
 			printf("   -D%-20.20s %s\n", hlp[0], hlp[1]);
 	}

--- a/src/sound.h
+++ b/src/sound.h
@@ -7,8 +7,8 @@
 
 struct sound_driver {
 	const char *id;
-	const char *description;
 	const char *const *help;
+	const char * (*description)(void);
 	int (*init)(struct options *);
 	void (*deinit)(void);
 	void (*play)(void *, int);
@@ -23,7 +23,7 @@ extern const struct sound_driver sound_aiff;
 extern const struct sound_driver sound_file;
 extern const struct sound_driver sound_qnx;
 extern const struct sound_driver sound_alsa05;
-extern       struct sound_driver sound_oss;
+extern const struct sound_driver sound_oss;
 extern const struct sound_driver sound_alsa;
 extern const struct sound_driver sound_os2dart;
 extern const struct sound_driver sound_win32;

--- a/src/sound_ahi.c
+++ b/src/sound_ahi.c
@@ -137,10 +137,14 @@ static void onpause(void) {
 static void onresume(void) {
 }
 
+static const char *description(void) {
+    return "Amiga AHI audio";
+}
+
 const struct sound_driver sound_ahi = {
     "ahi",
-    "Amiga AHI audio",
     NULL,
+    description,
     init,
     deinit,
     play,
@@ -148,4 +152,3 @@ const struct sound_driver sound_ahi = {
     onpause,
     onresume
 };
-

--- a/src/sound_aiff.c
+++ b/src/sound_aiff.c
@@ -152,10 +152,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "AIFF writer";
+}
+
 const struct sound_driver sound_aiff = {
 	"aiff",
-	"AIFF writer",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_aix.c
+++ b/src/sound_aix.c
@@ -118,6 +118,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "AIX PCM audio";
+}
+
 static const char *const help[] = {
 	"gain=val", "Audio output gain (0 to 255)",
 	/* "buffer=val", "Audio buffer size (default is 32768)", */
@@ -126,8 +131,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_bsd = {
 	"aix",
-	"AIX PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_alsa.c
+++ b/src/sound_alsa.c
@@ -109,6 +109,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "ALSA PCM audio";
+}
+
 static const char *const help[] = {
 	"buffer=num", "Set the ALSA buffer time in milliseconds",
 	"period=num", "Set the ALSA period time in milliseconds",
@@ -118,8 +123,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_alsa = {
 	"alsa",
-	"ALSA PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,
@@ -127,3 +132,4 @@ const struct sound_driver sound_alsa = {
 	onpause,
 	onresume
 };
+

--- a/src/sound_alsa05.c
+++ b/src/sound_alsa05.c
@@ -194,6 +194,11 @@ static void flush(void)
 	prepare_driver();
 }
 
+static const char *description(void)
+{
+	return "ALSA 0.5 PCM audio";
+}
+
 static const char *const help[] = {
 	"frag=num,size", "Set the number and size (bytes) of fragments",
 	"card <name>", "Select sound card to use",
@@ -202,8 +207,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_alsa05 = {
 	"alsa05",		/* driver ID */
-	"ALSA 0.5 PCM audio",	/* driver description */
 	help,			/* help */
+	description,		/* driver description */
 	init,			/* init */
 	dshutdown,		/* shutdown */
 	dummy,			/* starttimer */

--- a/src/sound_beos.cpp
+++ b/src/sound_beos.cpp
@@ -35,6 +35,7 @@ static const char *const help[] = {
 	NULL
 };
 
+static const char *description(void);
 static int init(struct options *options);
 static void deinit(void);
 static void play(void *b, int i);
@@ -44,8 +45,8 @@ static void onresume(void);
 
 const struct sound_driver sound_beos = {
 	"beos",
-	"BeOS PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,
@@ -204,4 +205,9 @@ static void onpause(void)
 
 static void onresume(void)
 {
+}
+
+static const char *description(void)
+{
+	return "BeOS PCM audio";
 }

--- a/src/sound_bsd.c
+++ b/src/sound_bsd.c
@@ -94,6 +94,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "BSD PCM audio";
+}
+
 static const char *const help[] = {
 	"gain=val", "Audio output gain (0 to 255)",
 	"buffer=val", "Audio buffer size (default is 32768)",
@@ -102,8 +107,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_bsd = {
 	"bsd",
-	"BSD PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_coreaudio.c
+++ b/src/sound_coreaudio.c
@@ -267,10 +267,15 @@ static void onresume(void)
 	AudioOutputUnitStart(au);
 }
 
+static const char *description(void)
+{
+	return "CoreAudio sound output";
+}
+
 const struct sound_driver sound_coreaudio = {
 	"coreaudio",
-	"CoreAudio sound output",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_dart.c
+++ b/src/sound_dart.c
@@ -212,6 +212,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "OS/2 Direct Audio Realtime";
+}
+
 static const char *const help[] = {
 	"sharing={Y,N}", "Device Sharing    (default is N)",
 	"device=val", "OS/2 Audio Device (default is 0 auto-detect)",
@@ -221,8 +226,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_os2dart = {
 	"dart",
-	"OS/2 Direct Audio Realtime",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_file.c
+++ b/src/sound_file.c
@@ -72,6 +72,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "Raw file writer";
+}
+
 static const char * const help[] = {
 	"endian=big", "Force big-endian 16-bit samples",
 	"endian=little", "Force little-endian 16-bit samples",
@@ -80,8 +85,8 @@ static const char * const help[] = {
 
 const struct sound_driver sound_file = {
 	"file",
-	"Raw file writer",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_hpux.c
+++ b/src/sound_hpux.c
@@ -139,6 +139,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "HP-UX PCM audio";
+}
+
 static const char *const help[] = {
 	"gain=val", "Audio output gain (0 to 255)",
 	"port={s|h|l}", "Audio port (s[peaker], h[eadphones], l[ineout])",
@@ -148,8 +153,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_hpux = {
 	"hpux",
-	"HP-UX PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,
@@ -157,3 +162,4 @@ const struct sound_driver sound_hpux = {
 	onpause,
 	onresume
 };
+

--- a/src/sound_netbsd.c
+++ b/src/sound_netbsd.c
@@ -124,6 +124,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "NetBSD PCM audio";
+}
+
 static const char *const help[] = {
 	"gain=val", "Audio output gain (0 to 255)",
 	"buffer=val", "Audio buffer size (default is 32768)",
@@ -132,8 +137,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_netbsd = {
 	"netbsd",
-	"NetBSD PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_null.c
+++ b/src/sound_null.c
@@ -34,11 +34,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "null output";
+}
 
 const struct sound_driver sound_null = {
 	"null",
-	"null output",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,
@@ -46,3 +50,4 @@ const struct sound_driver sound_null = {
 	onpause,
 	onresume
 };
+

--- a/src/sound_pulseaudio.c
+++ b/src/sound_pulseaudio.c
@@ -82,10 +82,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "PulseAudio sound output";
+}
+
 const struct sound_driver sound_pulseaudio = {
 	"pulseaudio",
-	"PulseAudio sound output",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_qnx.c
+++ b/src/sound_qnx.c
@@ -105,6 +105,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "QNX PCM audio";
+}
+
 static const char *const help[] = {
 	"dev=<device_name>", "Audio device name (default is /dev/dsp)",
 	"buffer=val", "Audio buffer size (default is 32768)",
@@ -113,8 +118,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_qnx = {
 	"QNX",
-	"QNX PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_sb.c
+++ b/src/sound_sb.c
@@ -150,10 +150,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "Sound Blaster for DOS";
+}
+
 const struct sound_driver sound_sb = {
 	"sb",
-	"Sound Blaster for DOS",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_sgi.c
+++ b/src/sound_sgi.c
@@ -167,6 +167,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "SGI IRIX PCM audio";
+}
+
 static const char *const help[] = {
 	"buffer=val", "Audio buffer size",
 	NULL
@@ -174,8 +179,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_sgi = {
 	"sgi",
-	"SGI IRIX PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_sndio.c
+++ b/src/sound_sndio.c
@@ -100,10 +100,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "OpenBSD sndio";
+}
+
 const struct sound_driver sound_sndio = {
 	"sndio",
-	"OpenBSD sndio",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_solaris.c
+++ b/src/sound_solaris.c
@@ -170,6 +170,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "Solaris PCM audio";
+}
+
 static const char *const help[] = {
 	"gain=val", "Audio output gain (0 to 255)",
 	"port={s|h|l}", "Audio port (s[peaker], h[eadphones], l[ineout])",
@@ -179,8 +184,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_solaris = {
 	"solaris",
-	"Solaris PCM audio",
 	help,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_wav.c
+++ b/src/sound_wav.c
@@ -138,10 +138,15 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "WAV writer";
+}
+
 const struct sound_driver sound_wav = {
 	"wav",
-	"WAV writer",
 	NULL,
+	description,
 	init,
 	deinit,
 	play,

--- a/src/sound_win32.c
+++ b/src/sound_win32.c
@@ -169,6 +169,11 @@ static void onresume(void)
 {
 }
 
+static const char *description(void)
+{
+	return "Windows WinMM sound output";
+}
+
 static const char *const help[] = {
 	"buffers=val", "Number of buffers (default 10)",
 	NULL
@@ -176,8 +181,8 @@ static const char *const help[] = {
 
 const struct sound_driver sound_win32 = {
 	"win32",
-	"Windows WinMM sound output",
 	help,
+	description,
 	init,
 	deinit,
 	play,
@@ -185,4 +190,3 @@ const struct sound_driver sound_win32 = {
 	onpause,
 	onresume
 };
-


### PR DESCRIPTION
This is after PR/#65, and removes the TODO note in sound_oss. It
also opens a way to reverting commit 0e44b4eb and adapting things
to this new setup. Created this pull request so that it won't get
forgotten.

@AliceLR suggested that the sound_oss driver description should be
computed by the description function, and returned via a caller-
owned buffer: Haven't done that myself, at least not yet

Feel free to push to this branch to improve things.

CC: @ccawley2011
