### PR TITLE
Unmute initially muted channels only if -S/--solo is provided.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,8 @@ Stable versions
 	Changes by Alice Rowan
 	- Report pan value "---" for instruments/samples without
 	  a default panning value (sub->pan < 0).
+	- Don't unmute muted IT channels unless explicitly unmuted by
+	  the -S/--solo option.
 
 4.2.0 (20230615):
 	Changes by Özkan Sezer:

--- a/src/main.c
+++ b/src/main.c
@@ -283,6 +283,9 @@ int main(int argc, char **argv)
 	opt.dsp = XMP_DSP_LOWPASS;
 	opt.player_mode = XMP_MODE_AUTO;
 	opt.amplify = 1;
+	for (i = 0; i < XMP_MAX_CHANNELS; i++) {
+		opt.mute[i] = -1; /* Use module default mute/unmute state */
+	}
 
 	/* read configuration file */
 	if (!opt.norc) {
@@ -484,7 +487,12 @@ int main(int argc, char **argv)
 			/* Mute channels */
 
 			for (i = 0; i < XMP_MAX_CHANNELS; i++) {
-				xmp_channel_mute(xc, i, opt.mute[i]);
+				/* Only mute/unmute if an option has been
+				 * provided explicitly (to avoid unmuting
+				 * disabled channels in IT et al.) */
+				if (opt.mute[i] >= 0) {
+					xmp_channel_mute(xc, i, opt.mute[i]);
+				}
 			}
 
 			/* Set player flags */


### PR DESCRIPTION
Fixes xmp-cli unmuting initially muted IT channels by default, causing incorrect sounds to play in various modules.

Examples: channels 15-23 of [Cyclone/almagest.it](https://ftp.modland.com/pub/modules/Impulsetracker/Cyclone/almagest.it), channel 8 of [Bombardment II](https://modarchive.org/index.php?request=view_by_moduleid&query=194589), and channel 4 of [Zeux Champion](https://modarchive.org/index.php?request=view_by_moduleid&query=194586).

Fixes #71.