### PR TITLE
Add support for 24-bit and 32-bit audio output.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,12 +3,25 @@ Stable versions
 
 4.2.1 (?):
 	Changes by Alice Rowan
+	- Support 24-bit and 32-bit output (requires libxmp 4.7.0+):
+	  ALSA, BeOS/Haiku, CoreAudio, NetBSD, OSS, PulseAudio,
+	  sndio, WinMM, AIFF, file, WAV.
+	- Use XMP_MAX_SRATE as the limit for -f instead of 48000
+	  (requires libxmp 4.7.0+).
 	- Report pan value "---" for instruments/samples without
 	  a default panning value (sub->pan < 0).
 	- Don't unmute muted IT channels unless explicitly unmuted by
 	  the -S/--solo option.
-	- Use XMP_MAX_SRATE as the limit for -f instead of 48000.
 	- Haiku: Fix configure C++11 detection error message.
+	- ALSA: fix 8-bit and unsigned format mismatches after init.
+	- BeOS/Haiku: support 8-bit unsigned, strip unsigned otherwise.
+	- NetBSD: find the nearest match for the requested format.
+	- PulseAudio: support 8-bit output.
+	- WinMM: support 8-bit unsigned, strip unsigned otherwise.
+	- file: fix incorrect handling of -Dendian ("big" would output
+	  little endian, anything else would output big endian).
+	- wav: fix incorrect RIFF length in output.
+	- wav: add terminal pad byte after odd length data chunks.
 
 4.2.0 (20230615):
 	Changes by Özkan Sezer:

--- a/README
+++ b/README
@@ -59,7 +59,7 @@ directly to cmatsuoka@gmail.com.
 LICENSE
 
 Extended Module Player
-Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,11 @@
 
 #include <xmp.h>
 
+/* Allow building with <4.7.0 for now... */
+#if XMP_VERCODE < 0x040700
+#define XMP_FORMAT_32BIT	(1 << 3)
+#endif
+
 struct player_mode {
 	const char *name;
 	const char *desc;
@@ -33,6 +38,7 @@ struct options {
 	int amplify;		/* amplification factor */
 	int rate;		/* sampling rate */
 	int format;		/* sample format */
+	int format_downmix;	/* XMP_FORMAT_32BIT may require downmix to 24 */
 	int max_time;		/* max. replay time */
 	int mix;		/* channel separation */
 	int defpan;		/* default pan */

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -336,15 +336,16 @@ int main(int argc, char **argv)
 
 	if (opt.verbose > 0) {
 		report("Extended Module Player " VERSION "\n"
-			"Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr\n");
+			"Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr\n");
 
 		report("Using %s\n", sound->description());
 
-		report("Mixer set to %d Hz, %dbit, %s%s%s\n", opt.rate,
-		    opt.format & XMP_FORMAT_8BIT ? 8 : 16,
+		report("Mixer set to %d Hz, %dbit, %s%s%s%s\n", opt.rate,
+		    get_bits_from_format(&opt),
+		    get_signed_from_format(&opt) ? "signed " : "unsigned ",
 		    opt.interp == XMP_INTERP_LINEAR ? "linear interpolated " :
 		    opt.interp == XMP_INTERP_SPLINE ? "cubic spline interpolated " : "",
-		    opt.format & XMP_FORMAT_MONO ? "mono" : "stereo",
+		    get_channels_from_format(&opt) == 1 ? "mono" : "stereo",
 		    opt.dsp & XMP_DSP_LOWPASS ? "" : " (no filter)");
 
 		report("Press 'h' for help\n\n");

--- a/src/options.c
+++ b/src/options.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -96,7 +96,7 @@ static void usage(char *s, struct options *options)
 "\nMixer options:\n"
 "   -A --amiga             Use Paula simulation mixer in Amiga formats\n"
 "   -a --amplify {0|1|2|3} Amplification factor: 0=Normal, 1=x2, 2=x4, 3=x8\n"
-"   -b --bits {8|16}       Software mixer resolution (8 or 16 bits)\n"
+"   -b --bits {8|16|24|32} Software mixer resolution (8, 16, 24, or 32 bits)\n"
 "   -c --stdout            Mix the module to stdout\n"
 "   -f --frequency rate    Sampling rate in hertz (default 44100)\n"
 "   -i --interpolation {nearest|linear|spline}\n"
@@ -190,8 +190,19 @@ void get_options(int argc, char **argv, struct options *options)
 			options->amplify = atoi(optarg);
 			break;
 		case 'b':
-			if (atoi(optarg) == 8) {
+			options->format &= ~(XMP_FORMAT_8BIT | XMP_FORMAT_32BIT);
+			options->format_downmix = 0;
+			switch (atoi(optarg)) {
+			case 8:
 				options->format |= XMP_FORMAT_8BIT;
+				break;
+			case 24:
+				options->format |= XMP_FORMAT_32BIT;
+				options->format_downmix = 24;
+				break;
+			case 32:
+				options->format |= XMP_FORMAT_32BIT;
+				break;
 			}
 			break;
 		case 'C':
@@ -387,7 +398,11 @@ void get_options(int argc, char **argv, struct options *options)
 
 	if (xmp_vercode < 0x040700) {
 		if (options->rate > 48000)
-			options->rate = 48000;	/* Old max. rate 48kHz */
+			options->rate = 48000;	/* Old max. rate 48 kHz */
+
+		options->format &= ~XMP_FORMAT_32BIT;
+		options->format_downmix = 0;
+
 	}
 
 	/* apply guess if no driver selected */

--- a/src/sound.h
+++ b/src/sound.h
@@ -58,13 +58,79 @@ extern const struct sound_driver *const sound_driver_list[];
 #define chkparm2(x,y,z,w) { if (!strcmp(s, x)) { \
 	if (2 > sscanf(token, y, z, w)) parm_error(); } }
 
-static inline int is_big_endian(void) {
+static inline int is_big_endian(void)
+{
 	unsigned short w = 0x00ff;
 	return (*(char *)&w == 0x00);
 }
 
+static inline int get_bits_from_format(const struct options *options)
+{
+	if ((options->format & XMP_FORMAT_32BIT) && options->format_downmix != 24) {
+		return 32;
+	} else if (options->format & XMP_FORMAT_32BIT) {
+		return 24;
+	} else if (~options->format & XMP_FORMAT_8BIT) {
+		return 16;
+	} else {
+		return 8;
+	}
+}
+
+static inline int get_signed_from_format(const struct options *options)
+{
+	return !(options->format & XMP_FORMAT_UNSIGNED);
+}
+
+static inline int get_channels_from_format(const struct options *options)
+{
+	return options->format & XMP_FORMAT_MONO ? 1 : 2;
+}
+
+static inline void update_format_bits(struct options *options, int bits)
+{
+	options->format &= ~(XMP_FORMAT_32BIT | XMP_FORMAT_8BIT);
+	options->format_downmix = 0;
+
+	switch (bits) {
+	case 8:
+		options->format |= XMP_FORMAT_8BIT;
+		break;
+	case 24:
+		options->format |= XMP_FORMAT_32BIT;
+		options->format_downmix = 24;
+		break;
+	case 32:
+		options->format |= XMP_FORMAT_32BIT;
+		break;
+	}
+}
+
+static inline void update_format_signed(struct options *options, int is_signed)
+{
+	if (!is_signed) {
+		options->format |= XMP_FORMAT_UNSIGNED;
+	} else {
+		options->format &= ~XMP_FORMAT_UNSIGNED;
+	}
+}
+
+static inline void update_format_channels(struct options *options, int channels)
+{
+	if (channels == 1) {
+		options->format |= XMP_FORMAT_MONO;
+	} else {
+		options->format &= ~XMP_FORMAT_MONO;
+	}
+}
+
 void init_sound_drivers(void);
 const struct sound_driver *select_sound_driver(struct options *);
-void convert_endian(unsigned char *, int);
+void downmix_32_to_24_aligned(unsigned char *, int);
+int downmix_32_to_24_packed(unsigned char *, int);
+void convert_endian_16bit(unsigned char *, int);
+void convert_endian_24bit(unsigned char *, int);
+void convert_endian_32bit(unsigned char *, int);
+void convert_endian(unsigned char *, int, int);
 
 #endif

--- a/src/sound_ahi.c
+++ b/src/sound_ahi.c
@@ -92,6 +92,7 @@ static int init(struct options *options) {
                         if (AHIBuf[1]) {
                             /* driver is initialized before calling libxmp, so this is OK : */
                             options->format &= ~XMP_FORMAT_UNSIGNED;/* no unsigned with AHI */
+                            options->format &= ~XMP_FORMAT_32BIT;
                             return 0;
                         }
                     }

--- a/src/sound_aix.c
+++ b/src/sound_aix.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -83,6 +83,8 @@ static int init(struct options *options)
 		close(audio_fd);
 		return -1;
 	}
+	options->format &= ~XMP_FORMAT_32BIT;
+
 	return 0;
 }
 

--- a/src/sound_alsa05.c
+++ b/src/sound_alsa05.c
@@ -159,6 +159,7 @@ static int init(struct options *options)
 		printf("Unable to setup channel: %s\n", snd_strerror(rc));
 		return -1;
 	}
+	options->format &= ~XMP_FORMAT_32BIT;
 
 	return 0;
 }

--- a/src/sound_bsd.c
+++ b/src/sound_bsd.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -42,7 +42,7 @@ static int init(struct options *options)
 	AUDIO_INITINFO(&ainfo);
 
 	ainfo.play.sample_rate = options->rate;
-	ainfo.play.channels = options->format & XMP_FORMAT_MONO ? 1 : 2;
+	ainfo.play.channels = get_channels_from_format(options);
 	ainfo.play.gain = gain;
 	ainfo.play.buffer_size = bsize;
 
@@ -60,6 +60,7 @@ static int init(struct options *options)
 		close(audio_fd);
 		return -1;
 	}
+	options->format &= ~XMP_FORMAT_32BIT;
 
 	return 0;
 }

--- a/src/sound_hpux.c
+++ b/src/sound_hpux.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -101,6 +101,7 @@ static int init(struct options *options)
 
 	ioctl(audio_fd, AUDIO_SET_TXBUFSIZE, bsize);
 
+	options->format &= ~XMP_FORMAT_32BIT;
 	return 0;
 
     err1:

--- a/src/sound_netbsd.c
+++ b/src/sound_netbsd.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -22,7 +22,67 @@
 
 static int audio_fd;
 static int audioctl_fd;
+static int bits;
 
+
+#define MATCH_ENCODING(s, r) \
+	((r) == AUDIO_ENCODING_ULINEAR ? \
+	  ((s) == AUDIO_ENCODING_ULINEAR || (s) == native_unsigned) : \
+	  ((s) == AUDIO_ENCODING_SLINEAR || (s) == native_signed))
+
+#define ANY_LINEAR(s) \
+	((s) == AUDIO_ENCODING_ULINEAR || (s) == native_unsigned || \
+	 (s) == AUDIO_ENCODING_SLINEAR || (s) == native_signed)
+
+static void to_fmt(int *precision, int *encoding, const struct options *options)
+{
+	/* The NE defines only exist in kernel space for some reason... */
+	int native_signed = is_big_endian()   ? AUDIO_ENCODING_SLINEAR_BE :
+						AUDIO_ENCODING_SLINEAR_LE;
+	int native_unsigned = is_big_endian() ? AUDIO_ENCODING_ULINEAR_BE :
+						AUDIO_ENCODING_ULINEAR_LE;
+
+	audio_encoding_t enc;
+	int match_precision = -1;
+	int match_encoding = -1;
+	int depth, uns, i;
+
+	depth = get_bits_from_format(options);
+	uns = get_signed_from_format(options) ? AUDIO_ENCODING_SLINEAR :
+						AUDIO_ENCODING_ULINEAR;
+
+	memset(&enc, 0, sizeof(enc));
+
+	for (i = 0; i < 100; i++) {
+		enc.index = i;
+		if (ioctl(audioctl_fd, AUDIO_GETENC, &enc) < 0) {
+			break;
+		}
+		if (enc.precision < depth ||
+		    (enc.precision > depth && match_precision == depth) ||
+		    !ANY_LINEAR(enc.encoding)) {
+			continue;
+		}
+		if (enc.precision == depth || MATCH_ENCODING(enc.encoding, uns)) {
+			match_precision = enc.precision;
+			match_encoding = enc.encoding;
+		}
+		if (enc.precision == depth && MATCH_ENCODING(enc.encoding, uns)) {
+			break;
+		}
+	}
+	if (match_precision >= 0) {
+		*precision = match_precision;
+		*encoding = match_encoding;
+	}
+}
+
+static int is_signed(int encoding)
+{
+	return encoding == AUDIO_ENCODING_SLINEAR ||
+		encoding == AUDIO_ENCODING_SLINEAR_BE ||
+		encoding == AUDIO_ENCODING_SLINEAR_LE;
+}
 
 static int init(struct options *options)
 {
@@ -30,6 +90,8 @@ static int init(struct options *options)
 	audio_info_t ainfo;
 	int gain = 128;
 	int bsize = 32 * 1024;
+	int precision = 16;
+	int encoding = AUDIO_ENCODING_SLINEAR;
 
 	parm_init(parm);
 	chkparm1("gain", gain = strtoul(token, NULL, 0));
@@ -59,6 +121,8 @@ static int init(struct options *options)
 		return -1;
 	}
 
+	to_fmt(&precision, &encoding, options);
+
 	close(audioctl_fd);
 
 	if (gain < AUDIO_MIN_GAIN)
@@ -70,18 +134,9 @@ static int init(struct options *options)
 
 	ainfo.mode = AUMODE_PLAY_ALL;
 	ainfo.play.sample_rate = options->rate;
-	ainfo.play.channels = options->format & XMP_FORMAT_MONO ? 1 : 2;
-
-	if (options->format & XMP_FORMAT_8BIT) {
-		ainfo.play.precision = 8;
-		ainfo.play.encoding = AUDIO_ENCODING_ULINEAR;
-		options->format |= XMP_FORMAT_UNSIGNED;
-	} else {
-		ainfo.play.precision = 16;
-		ainfo.play.encoding = AUDIO_ENCODING_SLINEAR;
-		options->format &= ~XMP_FORMAT_UNSIGNED;
-	}
-
+	ainfo.play.channels = get_channels_from_format(options);
+	ainfo.play.precision = precision;
+	ainfo.play.encoding = encoding;
 	ainfo.play.gain = gain;
 	ainfo.play.buffer_size = bsize;
 	ainfo.blocksize = 0;
@@ -91,12 +146,20 @@ static int init(struct options *options)
 		return -1;
 	}
 
+	update_format_bits(options, precision);
+	update_format_signed(options, is_signed(encoding));
+	bits = precision;
+
 	return 0;
 }
 
 static void play(void *b, int i)
 {
 	int j;
+
+	if (bits == 24) {
+		downmix_32_to_24_aligned(b, i);
+	}
 
 	while (i) {
 		if ((j = write(audio_fd, b, i)) > 0) {

--- a/src/sound_pulseaudio.c
+++ b/src/sound_pulseaudio.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -12,17 +12,39 @@
 #include "sound.h"
 
 static pa_simple *s;
+static int bits;
 
 
 static int init(struct options *options)
 {
 	pa_sample_spec ss;
+	int format = -1;
 	int error;
 
-	options->format &= ~(XMP_FORMAT_UNSIGNED | XMP_FORMAT_8BIT);
+	bits = get_bits_from_format(options);
+	switch (bits) {
+	case 8:
+		format = PA_SAMPLE_U8;
+		break;
+	case 16:
+	default:
+		format = PA_SAMPLE_S16NE;
+		break;
+#ifdef PA_SAMPLE_S24_32NE
+	case 24:
+		format = PA_SAMPLE_S24_32NE;
+		break;
+#endif
+#ifdef PA_SAMPLE_S32NE
+	case 32:
+		format = PA_SAMPLE_S32NE;
+		bits = 32;
+		break;
+#endif
+	}
 
-	ss.format = PA_SAMPLE_S16NE;
-	ss.channels = options->format & XMP_FORMAT_MONO ? 1 : 2;
+	ss.format = format;
+	ss.channels = get_channels_from_format(options);
 	ss.rate = options->rate;
 
 	s = pa_simple_new(NULL,		/* Use the default server */
@@ -40,12 +62,18 @@ static int init(struct options *options)
 		return -1;
 	}
 
+	update_format_bits(options, bits);
+	update_format_signed(options, bits != 8);
 	return 0;
 }
 
 static void play(void *b, int i)
 {
 	int j, error;
+
+	if (bits == 24) {
+		downmix_32_to_24_aligned(b, i);
+	}
 
 	do {
 		if ((j = pa_simple_write(s, b, i, &error)) > 0) {

--- a/src/sound_qnx.c
+++ b/src/sound_qnx.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -66,6 +66,7 @@ static int init(struct options *options)
 		goto error;
 	}
 
+	options->format &= ~XMP_FORMAT_32BIT;
 	return 0;
 
     error:

--- a/src/sound_sb.c
+++ b/src/sound_sb.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -65,6 +65,7 @@ static int init(struct options *options)
 	const char *card = NULL;
 	const char *mode = NULL;
 	int bits = 0;
+	int chn = 1;
 
 	if (!sb_open()) {
 		fprintf(stderr, "Sound Blaster initialization failed.\n");
@@ -76,9 +77,6 @@ static int init(struct options *options)
 		card = "16";
 		mode = "stereo";
 		bits = 16;
-		options->format &= ~XMP_FORMAT_8BIT;
-	} else {
-		options->format |= XMP_FORMAT_8BIT|XMP_FORMAT_UNSIGNED;
 	}
 	if (sb.caps & SBMODE_STEREO) {
 		if (!card) {
@@ -86,16 +84,15 @@ static int init(struct options *options)
 			mode = "stereo";
 			bits = 8;
 		}
+		chn = 2;
 		if (options->rate > sb.maxfreq_stereo)
 			options->rate = sb.maxfreq_stereo;
-		options->format &= ~XMP_FORMAT_MONO;
 	} else {
 		mode = "mono";
-		card = (sb.dspver < SBVER_20)? "1" : "2";
+		card = (sb.dspver < SBVER_20) ? "1" : "2";
 		bits = 8;
 		if (options->rate > sb.maxfreq_mono)
 			options->rate = sb.maxfreq_mono;
-		options->format |= XMP_FORMAT_MONO;
 	}
 
 	/* Enable speaker output */
@@ -113,8 +110,12 @@ static int init(struct options *options)
 		fprintf(stderr, "Sound Blaster: DMA start failed.\n");
 		return -1;
 	}
+	update_format_bits(options, bits);
+	update_format_signed(options, bits != 8);
+	update_format_channels(options, chn);
 
-	printf("Sound Blaster %s or compatible (%d bit, %s, %u Hz)\n", card, bits, mode, options->rate);
+	printf("Sound Blaster %s or compatible (%d bit, %s, %u Hz)\n",
+		card, bits, mode, options->rate);
 
 	return 0;
 }

--- a/src/sound_sgi.c
+++ b/src/sound_sgi.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -132,6 +132,7 @@ static int init(struct options *options)
 	if ((audio_port = ALopenport("xmp", "w", config)) == 0)
 		return -1;
 
+	options->format &= ~XMP_FORMAT_32BIT;
 	return 0;
 }
 

--- a/src/sound_solaris.c
+++ b/src/sound_solaris.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2016 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * This file is part of the Extended Module Player and is distributed
  * under the terms of the GNU General Public License. See the COPYING
@@ -137,6 +137,7 @@ static int init(struct options *options)
 		/* sound_solaris.description = "Solaris CS4231 PCM audio"; */
 	}
 
+	options->format &= ~XMP_FORMAT_32BIT;
 	return 0;
 }
 

--- a/src/xmp.1
+++ b/src/xmp.1
@@ -59,8 +59,8 @@ factors may cause distorted or noisy output\&.
 .IP "\fB\-A, \-\-amiga\fP" 
 Use a mixer which models the sound of an Amiga 500\&, with or without the led filter\&.
 .IP "\fB\-b, \-\-bits\fP \fIbits\fP" 
-Set the software mixer resolution (8 or 16 bits)\&. If omitted,
-The audio device will be opened at the highest resolution available\&.
+Set the software mixer resolution (8, 16, 24, or 32 bits)\&. If omitted,
+The audio device will be opened at 16-bit resolution\&.
 .IP "\fB\-C, \-\-show\-comments\fP" 
 Display module comment text, if any\&.
 .IP "\fB\-c, \-\-stdout\fP" 


### PR DESCRIPTION
Patches necessary to actually use the 32-bit output support added by https://github.com/libxmp/libxmp/pull/964 (see https://github.com/libxmp/libxmp/issues/924). This is a work in progress and can be finished after libxmp 4.7.0 is out.

Drivers with 24-bit and 32-bit audio support:
- [x] ALSA
- [x] BeOS/Haiku (only Haiku tested)
- [x] CoreAudio
- [x] NetBSD
- [x] OSS
- [x] PulseAudio
- [x] sndio
- [x] WinMM
- [x] AIFF file
- [x] Raw file
- [x] WAV file

Drivers that do not support 24-bit or 32-bit:
- [x] DART (compilation tested only)
- [x] Sound Blaster

Skipped drivers (I do not have a testing environment):
- [x] AHI
- [x] AIX
- [x] ALSA 0.5
- [x] BSD
- [x] HP-UX
- [x] QNX
- [x] SGI
- [x] Solaris