### PR TITLE
Haiku: fix configure C++ error message with -std=c++11

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,7 @@ Stable versions
 	- Don't unmute muted IT channels unless explicitly unmuted by
 	  the -S/--solo option.
 	- Use XMP_MAX_SRATE as the limit for -f instead of 48000.
+	- Haiku: Fix configure C++11 detection error message.
 
 4.2.0 (20230615):
 	Changes by Özkan Sezer:

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,8 @@ AC_PROG_CC
 AC_PROG_CXX
 case "$host_os" in
 beos*|haiku*)
-	AS_IF([! which "$CXX" >/dev/null 2>/dev/null],
+	# CXX may have -std=c++11 appended, do not wrap with quotes.
+	AS_IF([! command -v $CXX >/dev/null 2>/dev/null],
 		[AC_MSG_ERROR([C++ compiler required on this platform ($host_os)])])
 	CXXLD='$(CXX)'
 	;;


### PR DESCRIPTION
In my current Haiku (R1 beta 5) environment, configure will append `-std=c++11` to `CXX`. The `CXX` check for BeOS/Haiku uses `which "$CXX"`, which breaks when `CXX` contains options. I got rid of the quotes and switched it to `command -v` instead.

This has not been verified on actual BeOS, so if possible, please test that (I'm not aware how to, currently). edit: it's supposed to have Bash, but unclear if it's a version that supports -v?

Closes #78.