### PR TITLE
Add 32-bit support to the Amiga AHI driver.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,7 @@ Stable versions
 4.3.0 (?):
 	Changes by Alice Rowan
 	- Support 24-bit and 32-bit output (requires libxmp 4.7.0+):
-	  ALSA, BeOS/Haiku, CoreAudio, NetBSD, OSS, PulseAudio,
+	  AHI, ALSA, BeOS/Haiku, CoreAudio, NetBSD, OSS, PulseAudio,
 	  sndio, WinMM, AIFF, file, WAV.
 	- Use XMP_MAX_SRATE as the limit for -f instead of 48000
 	  (requires libxmp 4.7.0+).

--- a/src/sound_ahi.c
+++ b/src/sound_ahi.c
@@ -74,6 +74,8 @@ static void close_libs(void)
 static int init(struct options *options)
 {
 	unsigned long fmt;
+	int channels;
+	int bits;
 
 	AHImp = CreateMsgPort();
 	if (AHImp == NULL) {
@@ -97,10 +99,26 @@ static int init(struct options *options)
 		goto err;
 	}
 
-	if (options->format & XMP_FORMAT_8BIT) {
-		fmt = options->format & XMP_FORMAT_MONO ? AHIST_M8S : AHIST_S8S;
-	} else {
-		fmt = options->format & XMP_FORMAT_MONO ? AHIST_M16S : AHIST_S16S;
+	bits = get_bits_from_format(options);
+	channels = get_channels_from_format(options);
+
+	switch (bits) {
+	case 8:
+		fmt = (channels == 1) ? AHIST_M8S : AHIST_S8S;
+		bits = 8;
+		break;
+	case 16:
+	default:
+		fmt = (channels == 1) ? AHIST_M16S : AHIST_S16S;
+		bits = 16;
+		break;
+#if defined(AHIST_M32S) && defined(AHIST_S32S)
+	case 24:
+	case 32:
+		fmt = (channels == 1) ? AHIST_M32S : AHIST_S32S;
+		bits = 32;
+		break;
+#endif
 	}
 
 	AHIReq[0]->ahir_Std.io_Command = CMD_WRITE;
@@ -119,8 +137,9 @@ static int init(struct options *options)
 		goto err;
 	}
 
-	options->format &= ~XMP_FORMAT_UNSIGNED;
-	options->format &= ~XMP_FORMAT_32BIT;
+	update_format_bits(options, bits);
+	update_format_signed(options, 1);
+
 	active = 0;
 	return 0;
 


### PR DESCRIPTION
Both toolchains tested (bebbo GCC 6.5, adtools GCC 2.95) compile support with no issue. Audio initializes in the 32-bit modes with Paula (FS-UAE), but output is silent. There may be different results with different audio devices, but I don't have an emulated sound card set up currently.