### PR TITLE
AHI: fix crash on OpenDevice failure.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -13,6 +13,7 @@ Stable versions
 	- Don't unmute muted IT channels unless explicitly unmuted by
 	  the -S/--solo option.
 	- Haiku: Fix configure C++11 detection error message.
+	- AHI: fix crash on OpenDevice failure.
 	- ALSA: fix 8-bit and unsigned format mismatches after init.
 	- BeOS/Haiku: support 8-bit unsigned, strip unsigned otherwise.
 	- NetBSD: find the nearest match for the requested format.

--- a/src/sound_ahi.c
+++ b/src/sound_ahi.c
@@ -89,11 +89,6 @@ static int init(struct options *options)
 	}
 	AHIReq[0]->ahir_Version = 4;
 
-	AHIReq[1] = AllocVec(sizeof(struct AHIRequest), SHAREDMEMFLAG);
-	if (AHIReq[1] == NULL) {
-		goto err;
-	}
-
 	if (OpenDevice((CONST_STRPTR)AHINAME, AHI_DEFAULT_UNIT,
 			(struct IORequest *)AHIReq[0], 0) != 0) {
 		goto err;
@@ -129,6 +124,10 @@ static int init(struct options *options)
 	AHIReq[0]->ahir_Volume = 0x10000;
 	AHIReq[0]->ahir_Position = 0x8000;
 
+	AHIReq[1] = AllocVec(sizeof(struct AHIRequest), SHAREDMEMFLAG);
+	if (AHIReq[1] == NULL) {
+		goto err;
+	}
 	CopyMem(AHIReq[0], AHIReq[1], sizeof(struct AHIRequest));
 
 	AHIBuf[0] = AllocVec(BUFFERSIZE, SHAREDMEMFLAG | MEMF_CLEAR);


### PR DESCRIPTION
Attempting the `close_libs` cleanup routine on an `AHIRequest` that hasn't been properly initialized by `CreateIORequest`/`OpenDevice` appears to result in an instant crash. This patch moves the second `AHIRequest` allocation to immediately precede its initialization to avoid this issue.

Closes #89.